### PR TITLE
Role-Orgs mapping for OAuth

### DIFF
--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -235,6 +235,14 @@ func buildExternalUserInfo(token *oauth2.Token, userInfo *social.BasicUserInfo, 
 		}
 	}
 
+	if userInfo.IsGrafanaAdmin {
+		extUser.IsGrafanaAdmin = &userInfo.IsGrafanaAdmin
+	}
+
+	if len(userInfo.OrgRoles) > 0 {
+		extUser.OrgRoles = userInfo.OrgRoles
+	}
+
 	return extUser
 }
 

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -10,24 +10,61 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/mail"
+	"os"
 	"regexp"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/util/errutil"
 	"golang.org/x/oauth2"
 )
 
 type SocialGenericOAuth struct {
 	*SocialBase
-	allowedOrganizations []string
-	apiUrl               string
-	emailAttributeName   string
-	emailAttributePath   string
-	loginAttributePath   string
-	nameAttributePath    string
-	roleAttributePath    string
-	idTokenAttributeName string
-	teamIds              []int
+	allowedOrganizations         []string
+	apiUrl                       string
+	emailAttributeName           string
+	emailAttributePath           string
+	loginAttributePath           string
+	nameAttributePath            string
+	roleAttributePath            string
+	idTokenAttributeName         string
+	roleOrgAttributeMappingsFile string
+	teamIds                      []int
+}
+
+type RoleOrgsPathMappings struct {
+	RoleOrgsPathMappings []RoleOrgsPathMapping `json:"roleOrgsPathMappings"`
+}
+
+type RoleOrgsPathMapping struct {
+	Path string                    `json:"path"`
+	Data []RoleOrgsPathMappingData `json:"data"`
+}
+
+type RoleOrgsPathMappingData struct {
+	IsGrafanaAdmin bool             `json:"isGrafanaAdmin"`
+	Role           *models.RoleType `json:"role,omitempty"`
+	Organizations  []string         `json:"orgs"`
+}
+
+func (s *SocialGenericOAuth) LoadRoleOrgsPathMappings() *RoleOrgsPathMappings {
+	jsonFile, err := os.Open(s.roleOrgAttributeMappingsFile)
+
+	if err != nil {
+		s.log.Error("failed to load config from ", "file", s.roleOrgAttributeMappingsFile, "error", err)
+		return nil
+	}
+
+	s.log.Debug("Successfully Opened", "file", s.roleOrgAttributeMappingsFile)
+	defer jsonFile.Close()
+
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+
+	var roleOrgsPathMappings RoleOrgsPathMappings
+	json.Unmarshal(byteValue, &roleOrgsPathMappings)
+
+	return &roleOrgsPathMappings
 }
 
 func (s *SocialGenericOAuth) Type() int {
@@ -148,6 +185,44 @@ func (s *SocialGenericOAuth) UserInfo(client *http.Client, token *oauth2.Token) 
 			} else if role != "" {
 				s.log.Debug("Setting user info role from extracted role")
 				userInfo.Role = role
+			}
+		}
+
+		if s.roleOrgAttributeMappingsFile != "" {
+			orgRoles := make(map[int64]models.RoleType)
+			s.log.Debug("Loading JSON config file", "roleOrgAttributeMappingsFile", s.roleOrgAttributeMappingsFile)
+			mappings := *s.LoadRoleOrgsPathMappings()
+
+			for _, roleOrgsPathMapping := range mappings.RoleOrgsPathMappings {
+				s.log.Debug("Searching for path among JSON", "path", roleOrgsPathMapping.Path)
+				result, err := s.searchJSONForAttr(roleOrgsPathMapping.Path+" && 'found' || ''", data.rawJSON)
+
+				if err != nil {
+					s.log.Error("Failed to search JSON for path", "error", err)
+				} else if result != "" {
+					for _, roleOrgsPathMappingData := range roleOrgsPathMapping.Data {
+						if roleOrgsPathMappingData.IsGrafanaAdmin {
+							s.log.Debug("User marked as grafana server admin")
+							userInfo.IsGrafanaAdmin = true
+						}
+						for _, roleOrgsPathMappingDataOrganization := range roleOrgsPathMappingData.Organizations {
+							query := &models.SearchOrgsQuery{Name: roleOrgsPathMappingDataOrganization, Limit: 1}
+							err := sqlstore.SearchOrgs(query)
+							if err != nil {
+								s.log.Error("Failed to search for Org:"+roleOrgsPathMappingDataOrganization,
+									"error", err)
+							}
+							if len(query.Result) == 1 {
+								s.log.Debug("Adding/replacing role for matched user organization", "org",
+									query.Result[0].Id, "role", roleOrgsPathMappingData.Role)
+								orgRoles[query.Result[0].Id] = *roleOrgsPathMappingData.Role
+							}
+						}
+					}
+				}
+			}
+			if len(orgRoles) > 0 {
+				userInfo.OrgRoles = orgRoles
 			}
 		}
 	}

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -22,13 +23,15 @@ var (
 )
 
 type BasicUserInfo struct {
-	Id      string
-	Name    string
-	Email   string
-	Login   string
-	Company string
-	Role    string
-	Groups  []string
+	Id             string
+	Name           string
+	Email          string
+	Login          string
+	Company        string
+	Role           string
+	Groups         []string
+	OrgRoles       map[int64]models.RoleType
+	IsGrafanaAdmin bool
 }
 
 type SocialConnector interface {
@@ -177,16 +180,17 @@ func NewOAuthService() {
 		// Generic - Uses the same scheme as GitHub.
 		if name == "generic_oauth" {
 			SocialMap["generic_oauth"] = &SocialGenericOAuth{
-				SocialBase:           newSocialBase(name, &config, info),
-				apiUrl:               info.ApiUrl,
-				emailAttributeName:   info.EmailAttributeName,
-				emailAttributePath:   info.EmailAttributePath,
-				nameAttributePath:    sec.Key("name_attribute_path").String(),
-				roleAttributePath:    info.RoleAttributePath,
-				loginAttributePath:   sec.Key("login_attribute_path").String(),
-				idTokenAttributeName: sec.Key("id_token_attribute_name").String(),
-				teamIds:              sec.Key("team_ids").Ints(","),
-				allowedOrganizations: util.SplitString(sec.Key("allowed_organizations").String()),
+				SocialBase:                   newSocialBase(name, &config, info),
+				apiUrl:                       info.ApiUrl,
+				emailAttributeName:           info.EmailAttributeName,
+				emailAttributePath:           info.EmailAttributePath,
+				nameAttributePath:            sec.Key("name_attribute_path").String(),
+				roleAttributePath:            info.RoleAttributePath,
+				loginAttributePath:           sec.Key("login_attribute_path").String(),
+				idTokenAttributeName:         sec.Key("id_token_attribute_name").String(),
+				roleOrgAttributeMappingsFile: sec.Key("role_org_attribute_mappings_file").String(),
+				teamIds:                      sec.Key("team_ids").Ints(","),
+				allowedOrganizations:         util.SplitString(sec.Key("allowed_organizations").String()),
 			}
 		}
 


### PR DESCRIPTION
grafana.ini:
```
...
[auth.generic_oauth]
...
role_org_attribute_mappings_file = /etc/grafana/mapping.json
```
mapping.json:
```
{
  "roleOrgsPathMappings": [
    {
      "path": "contains(ldap_entry_dn, 'OU=something,')",
      "data": [
        {
          "isGrafanaAdmin": true
        }
      ]
    },
    {
      "path": "contains(ldap_entry_dn, 'OU=another_one,')",
      "data": [
        {
          "role": "Admin",
          "orgs": [
            "test",
            "test1"
          ]
        },
        {
          "role": "Editor",
          "orgs": [
            "test3"
          ]
        }
      ]
    },
    {
      "path": "contains(ldap_entry_dn, 'OU=something_else,')",
      "data": [
        {
          "role": "Admin",
          "orgs": [
            "test",
            "test1"
          ]
        }
      ]
    }
  ]
}
```